### PR TITLE
Replace prelude print macros with faster variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dmoj"
+version = "0.1.0"
+authors = ["Martin Muñoz <im.mmun@gmail.com>"]
+
+[dependencies]
+lazy_static = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,37 @@
+#[macro_use]
+extern crate lazy_static;
+
+mod sync;
+
+use std::io::{BufWriter, Stdout};
+use sync::NotThreadSafe;
+
+lazy_static! {
+    pub static ref STDOUT: NotThreadSafe<BufWriter<Stdout>> = {
+        NotThreadSafe::new(BufWriter::new(std::io::stdout()))
+    };
+}
+
+#[macro_export]
+macro_rules! println {
+    ($($arg:tt)*) => { {
+        use std::io::Write;
+
+        unsafe {
+            let stdout = $crate::STDOUT.get().as_mut().unwrap();
+            writeln!(stdout, $($arg)*).unwrap();
+        }
+    } }
+}
+
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => { {
+        use std::io::Write;
+
+        unsafe {
+            let stdout = $crate::STDOUT.get().as_mut().unwrap();
+            write!(stdout, $($arg)*).unwrap();
+        }
+    } }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,19 @@
+use std::cell::UnsafeCell;
+
+pub struct NotThreadSafe<T> {
+    value: UnsafeCell<T>
+}
+
+unsafe impl<T> Sync for NotThreadSafe<T> {}
+
+impl<T> NotThreadSafe<T> {
+    pub fn new(value: T) -> NotThreadSafe<T> {
+        NotThreadSafe {
+            value: UnsafeCell::new(value)
+        }
+    }
+
+    pub unsafe fn get(&self) -> *mut T {
+        self.value.get()
+    }
+}


### PR DESCRIPTION
This commit replaces the prelude print! and println! macros with variants that are around 10 times faster at the cost of losing thread safety, but this isn't an issue in an online judge setting.
