### PR TITLE
Flush stdout buffer at program exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/DMOJ/dmoj-rust"
 
 [dependencies]
 lazy_static = "0.2.1"
+libc = "0.2.16"

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 A Rust crate for providing helpful methods in online judging.
 
-## Macros
+- [Usage](#usage)
+- [Provided macros](#provided-macros)
 
-### `print!`, `println!` and `flush!`
-
-This crate exports `print!` and `println!` macros that shadow the prelude versions. These versions are about 10 times faster and fully API compatible, but sacrifice thread safety.
-
-Note: For now, you must manually `flush!` at the end of your program to ensure the stdout buffer is flushed:
+## Usage
 
 ```rust
-#[macro_use] extern crate dmoj;
+#[macro_use]
+extern crate dmoj;
 
 fn main() {
-    print!("Hello,");
-    println!(" World!");
-    flush!();
+    println!("Hello, World!");
 }
 ```
+
+## Provided macros
+
+### `print!`, `println!`
+
+This crate provides `print!` and `println!` macros that shadow the prelude versions. These versions are about 10 times faster and fully API compatible, but sacrifice thread safety.


### PR DESCRIPTION
This PR pulls in `libc` to flush the static buffer at exit via `libc::atexit`. No more `flush!`. 🚽 

Closes #2.
