### PR TITLE
feat: implement `String` scanner

### DIFF
--- a/src/scan.rs
+++ b/src/scan.rs
@@ -133,6 +133,27 @@ impl<R: Read> Scan<char> for CopyingBufReader<R> {
     }
 }
 
+impl<R: Read> Scan<String> for CopyingBufReader<R> {
+    fn scan(&mut self) -> String {
+        let mut s = String::new();
+
+        if self.peek().unwrap() as char == '\n' {
+            self.consume(1);
+        }
+        loop {
+            let c = self.peek().unwrap_or(b'\n') as char;
+            if c == '\n' {
+                // self.consume(1);
+                break;
+            } else {
+                self.consume(1);
+                s.push(c);
+            }
+        }
+        s
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use buf::CopyingBufReader;
@@ -219,5 +240,16 @@ mod tests {
         assert_eq!(Scan::<char>::scan(&mut buf), 'g');
         assert_eq!(Scan::<char>::scan(&mut buf), 'h');
         assert_eq!(Scan::<char>::scan(&mut buf), 'i');
+    }
+
+    #[test]
+    fn scanning_strings_works_correctly() {
+        let mut buf = CopyingBufReader::with_capacity(4, &b"crazy\npeter\npan\n1\n\nhotdog"[..]);
+        assert_eq!(Scan::<String>::scan(&mut buf), String::from("crazy"));
+        assert_eq!(Scan::<String>::scan(&mut buf), String::from("peter"));
+        assert_eq!(Scan::<String>::scan(&mut buf), String::from("pan"));
+        assert_eq!(Scan::<String>::scan(&mut buf), String::from("1"));
+        assert_eq!(Scan::<String>::scan(&mut buf), String::new());
+        assert_eq!(Scan::<String>::scan(&mut buf), String::from("hotdog"));
     }
 }


### PR DESCRIPTION
This pull request will make scanning for words in challenges much more simple for users. Using `scan!(String` will return a line of input.

Use:
(Stdin)
```
sample
string
```
(Code)
```rs
scan!(String);
let sample = scan!(String);
asserteq!(sample, String::from("string");
```

Note that normal stdin readline functions work by returning all characters until finding a newline and then clearing that newline to allow the next execution to start where it left off. However, the other scanners implementations don't check for and clear the following newline. So, this function instead checks if the first character being scanned is a newline and if so, ignores it.

Please provide feedback if you have any.